### PR TITLE
Version 1.1.1 - Hotstrings

### DIFF
--- a/Kozubenko.Assertions.psm1
+++ b/Kozubenko.Assertions.psm1
@@ -130,3 +130,12 @@ function AssertString($stringVarName, $string) {
         throw [System.Management.Automation.RuntimeException]::new("$stringVarName is Null or Empty")
     }
 }
+
+function AssertInt($str, $fail_message="") {
+    $result = 0
+    if ([int]::TryParse($str, [ref]$result)) {
+        return $result
+    } else {
+        throw "`e[38;5;214m$fail_message`e[0m"
+    }
+}

--- a/Kozubenko.Git.psm1
+++ b/Kozubenko.Git.psm1
@@ -6,38 +6,21 @@ class KozubenkoGit : IRegistry {
         return [HintRegistry]::new(
             "Kozubenko.Git",
             @(
+                "SquashCommits(`$commitMsg, `$n)      -->   (n = # of all commits being combined). force push included",
+                "ClearStashGit()                      -->   git stash clear",
                 "GitPage()                            -->   goes to remote.origin.url in the browser",
                 "GitStatus()                          -->   Clear-Host; git status"
-                "Push(`$commitMsg)                    -->   push to github repo. does not work with branches",
                 "GitLog(`$lines=4)                    -->   afterwards use: 'git show 06cb024'",
-                "GitUncommit()                        -->   redo your last pushed commit: git reset --mixed HEAD~1",
-                "SquashCommits(`$commitMsg, `$n)      -->   (n = # of all commits being combined). force push included",
-                "Rebase(`$commitsBack)                -->   [dd -> cut line] [P -> paste] [squash -> merges into above commit]",
 
-                "I want to update Submodules                -->  git submodule update --remote",
-                "I want to update Submodules, recursively   -->  git submodule update --remote --recursive",
+                "I am rebasing!                          -->   [dd -> cut line] [P -> paste] [fixup -> merges into above commit]",
+
+                "I want to update Submodules                -->  git submodule update --remote [--recursive]",
+                "I want to uncommit my last push            -->  git reset --mixed HEAD~1"
                 "I want to push new local branch to Github  -->  git push -u origin <branch-name>"
             ));
     }
 }
 
-function GitStatus() {
-    Clear-Host; git status
-}
-
-function Push($commitMsg = "No Commit Message") {
-    git add .
-    git commit -a -m $commitMsg
-    git push
-}
-
-function GitLog($lines=4) {
-    git log --oneline -$($lines)
-}
-
-function GitUncommit {
-    git reset --mixed HEAD~1
-}
 
 function GitPage($path = $PWD.Path) {
     function TryOpenGithub($path) {
@@ -57,25 +40,28 @@ function GitPage($path = $PWD.Path) {
     }
 }
 
-<#
-PLEASE LOOK INTO REPLACING "git push --force" with "git push --force-with-lease":
-This may work, needs testing:
-    $output = git push --force-with-lease 2>&1
-    $exitCode = $LASTEXITCODE
-#>
+function ClearStashGit() {
+    git stash clear
+}
+
+function GitStatus() {
+    Clear-Host; git status
+}
+
 function SquashCommits($commitMsg, $n) {
     if([string]::IsNullOrWhiteSpace($commitMsg)) {  PrintRed "SquashCommits(): cannot continue because`$commitMsg is null/whitespace."; RETURN;  }
     if($n -lt 2) {  PrintRed "SquashCommits(`$commitMsg, `$n): Requirement not met: `$n > 1"; RETURN;  }
 
     $need_stash = (git status --porcelain)
     if($need_stash) {
+        git stash clear
         git stash
     }
 
     git reset --soft HEAD~$($n - 1)
     git commit --amend -m $commitMsg
 
-    git push --force
+    git push --force-with-lease
     PrintGreen "Squashed & Force-Pushed to Remote"
 
     if($need_stash) {
@@ -83,23 +69,23 @@ function SquashCommits($commitMsg, $n) {
     }
 }
 
-function Rebase([int]$commitsBack) {
-    $global:rebaseStarted = $true
-
-    $stash_necessary = (git status --porcelain)
-    if($stash_necessary) {
-        git stash
-        PrintYellow "git stash-ed"
-    }
-    git rebase -i HEAD~$($commitsBack)
-}
-
 function GitConfig($email, $name) {
     git config --global user.email $email
     git config --global user.name $name
 }
 
-function RecursiveSubmoduleUpdate($force) {
-    if ($force) {  git submodule update --init --recursive --remote --force  }
-    else        {  git submodule update --init --recursive --remote          }
+function GitLog($lines=4) {
+    git log --oneline -$($lines)
 }
+
+
+<# 
+    :: The Fossil Record ::
+#>
+
+# "Push(`$commitMsg)                    -->   push to github repo. does not work with branches"
+# function Push($commitMsg = "No Commit Message") {
+#     git add .
+#     git commit -a -m $commitMsg
+#     git push
+# }

--- a/Kozubenko.Runtime.psm1
+++ b/Kozubenko.Runtime.psm1
@@ -140,22 +140,6 @@ class MyRuntime {
         [MyRuntime]::SaveToEnvFile($this._COMMANDS_FILE, $this.commands)
     }
 
-    # called from Console, by pressing Enter on empty buffer: ""
-    [void] RunDefaultCommand() {
-        $path = $PWD.Path
-
-        $buffer = $null; $cursor = 0;
-        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$buffer, [ref]$cursor)
-
-        $command = $this.commands[$path]
-        if($command) {
-            [Microsoft.PowerShell.PSConsoleReadLine]::Insert($command)  }
-        else {
-            [Microsoft.PowerShell.PSConsoleReadLine]::Insert("open " + $buffer)  }
-        
-        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-    }
-
     [void] OverridePreviousHistory() {
         if($this.last_path -ne $PWD.Path) {
             $this.last_path = $PWD.Path

--- a/Kozubenko.Utils.psm1
+++ b/Kozubenko.Utils.psm1
@@ -276,7 +276,24 @@ function TestPath($path) {
     Set-Variable/Set-Alias Utils
 ----------------------------------------------
 #>
-function SetAliases($function, [Array]$aliases) {   # Throws exception if you try to set an alias on a keyword you already set an alias on
+function SetAliasesFor($script_block, [Array]$aliases) {
+    <# 
+    .SYNOPSIS
+    Uses `New-Item` under the hood, not `Set-Alias`
+
+    PS > SetAliasesFor "git branch" @("b", "br", "bra")
+    #>
+    foreach ($alias in $aliases) {
+        New-Item -Path "Function:\Global:$alias" -Value $script_block -Force -ErrorAction Stop | Out-Null
+    }
+}
+function SetAliases($function, [Array]$aliases) {
+    <# 
+    .SYNOPSIS
+    A QoL wrapper for Set-Alias
+
+    throws: if alias already used
+    #>
     if ($function -eq $null -or $aliases -eq $null) {  RETURN  }
 
     foreach ($alias in $aliases) {

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -70,7 +70,7 @@ function Open($path = $PWD.Path) {
         }
     }
     else {  explorer.exe $path  }
-}   <# ALIAS: #>    function O($path = $PWD.Path) {  Open($path)  }
+}
 
 function Vs($path = $PWD.Path) {
     if (-not(Test-Path $path)) {  PrintRed "`$path is not a valid path. `$path == $path";  RETURN;  }

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -145,7 +145,7 @@ function OnOpen($debug_mode = $false) {
     }
     Set-PSReadLineKeyHandler -Key UpArrow         -Description "Runtime.OverridePreviousHistory()"  -ScriptBlock {  $global:MyRuntime.OverridePreviousHistory()  }
     Set-PSReadLineKeyHandler -Key DownArrow       -Description "Runtime.CycleCommands()"            -ScriptBlock {  $global:MyRuntime.CycleCommands()  }
-    Set-PSReadLineKeyHandler -Key Enter           -Description "Runtime.EnterKeyHandler()"          -ScriptBlock {
+    Set-PSReadLineKeyHandler -Key Enter           -Description "EnterKeyHandler()"                  -ScriptBlock {
         $global:MyRuntime.history_depth = 0
         $buffer, $cursor = GetConsoleBufferState
 
@@ -155,8 +155,7 @@ function OnOpen($debug_mode = $false) {
         if($buffer -eq "st")          {  ConsoleDeleteInput; ConsoleInsert "git stash ";           RETURN; }
         if($buffer.StartsWith("re"))  {  ConsoleDeleteInput;
             $int = AssertInt $buffer.Split(" ")[1] "Correct Form: 're {int}'"
-            ConsoleInsert "git rebase -i HEAD~$int"
-            RETURN;
+            ConsoleInsert "git rebase -i HEAD~$int";                           ConsoleAcceptLine;  RETURN;
         }
 
         elseif($buffer.StartsWith("..")) {

--- a/tests/Assert.Test.ps1
+++ b/tests/Assert.Test.ps1
@@ -1,0 +1,7 @@
+using module ..\Kozubenko.Assertions.psm1
+
+
+$int = AssertInt "5"
+$int = AssertInt "mary" "Correct Form: 're {int}'"
+
+PrintGreen "Stupid Test Passed"


### PR DESCRIPTION
## Version 1.1.1 - Hotstrings

### EnterKeyHandler()
- `re {int}` -> `git rebase -i HEAD~$int`
- `br` -> `git branch `
- `ch` -> `git checkout `
- `st` -> `git stash `


### Miscellaneous
- Git.psm1 - Spring Cleaning
- `AssertString` added, with test.
- `MyRuntime.RunDefaultCommand()` removed, replaced by `EnterKeyHandler()`